### PR TITLE
Add -loader to example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ var webpackConfig = {
     loaders: [
       {
         test: /\.js$/,
-        loader: 'unlazy'
+        loader: 'unlazy-loader'
       }
     ]
   }


### PR DESCRIPTION
It's no longer allowed to omit the '-loader' suffix when using loaders.